### PR TITLE
Set require_serial for hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,9 +4,11 @@
   entry: buildifier-wrapper.sh -mode=fix -lint=fix
   files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
   language: script
+  require_serial: true
 - id: buildifier-lint
   name: buildifier-lint
   description: Lint starlark code with buildifier
   entry: buildifier-wrapper.sh -mode=diff -lint=warn
   files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
   language: script
+  require_serial: true


### PR DESCRIPTION
* Using both the buildifier and buildifier-lint hooks in the same repo
  can result in the following error:
  /tmp/tmpf1zpl9gz/repo4uxyvgkf/buildifier-wrapper.sh: line 45:
  /home/user/.cache/pre-commit/buildifier/linux-amd64-4.2.0/buildifier/buildifier:
  Text file busy
* pre-commit will run the hooks in parallel by default and if both
  hooks try to download and write the buildifier-binary at the same time
  the above error will occur. Setting require_serial to true will make
  sure only one hook is run at the same time.