### PR TITLE
Save two buildifier binaries to avoid racing.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,12 +1,12 @@
 - id: buildifier
   name: buildifier
   description: Format starlark code with buildifier
-  entry: buildifier-wrapper.sh -mode=fix -lint=fix
+  entry: buildifier-wrapper.sh fix -mode=fix -lint=fix
   files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
   language: script
 - id: buildifier-lint
   name: buildifier-lint
   description: Lint starlark code with buildifier
-  entry: buildifier-wrapper.sh -mode=diff -lint=warn
+  entry: buildifier-wrapper.sh lint -mode=diff -lint=warn
   files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
   language: script

--- a/buildifier-wrapper.sh
+++ b/buildifier-wrapper.sh
@@ -25,7 +25,8 @@ fi
 readonly filename=buildifier-$os-$arch
 readonly url=https://github.com/bazelbuild/buildtools/releases/download/$version/$filename
 readonly binary_dir=~/.cache/pre-commit/buildifier/$os-$arch-$version/buildifier
-readonly binary=$binary_dir/buildifier
+readonly binary=$binary_dir/buildifier-$1
+shift
 
 if [[ -x "$binary" ]]; then
   exec "$binary" "$@"
@@ -42,10 +43,11 @@ if ! curl --fail --location --retry 5 --retry-connrefused --silent --output "$tm
 fi
 
 if echo "$sha  $tmp_binary" | shasum --check --status; then
+  chmod +x "$tmp_binary"
+
   # Protect against races of concurrent hooks downloading the same binary
   if [[ ! -x "$binary" ]]; then
     mv "$tmp_binary" "$binary"
-    chmod +x "$binary"
   fi
 
   exec "$binary" "$@"


### PR DESCRIPTION
The binary move does not fix the racing condition, but just mitigated it. It will still very likely show "Text file busy" error.

This PR simply uses a different binary name for the two pre-commit hooks that are defined in this repo.

