### PR TITLE
Support MODULE.bazel

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,11 +2,11 @@
   name: buildifier
   description: Format starlark code with buildifier
   entry: buildifier-wrapper.sh fix -mode=fix -lint=fix
-  files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
+  files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE|MODULE\.bazel)$|\.BUILD$|\.bzl$'
   language: script
 - id: buildifier-lint
   name: buildifier-lint
   description: Lint starlark code with buildifier
   entry: buildifier-wrapper.sh lint -mode=diff -lint=warn
-  files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
+  files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE|MODULE\.bazel)$|\.BUILD$|\.bzl$'
   language: script


### PR DESCRIPTION
Noticed when working on https//github.com/bazelbuild/rules_python, that the CI was failing because `MODULE.bazel` is not autoformatted by `buildifier` when using these hooks.
