### PR TITLE
use portable shebang for scripts

### DIFF
--- a/buildifier-wrapper.sh
+++ b/buildifier-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/getshas.sh
+++ b/getshas.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
I'm on a linux distribution where the assumption that bash is in `/bin/bash` is not true.
thus i propose to use `#!/usr/bin/env bash` instead for portability reasons.