### PR TITLE
fix: add aarch64 support

### DIFF
--- a/buildifier-wrapper.sh
+++ b/buildifier-wrapper.sh
@@ -19,7 +19,7 @@ if [[ $OSTYPE == darwin* ]]; then
 fi
 
 arch=amd64
-if [[ $(uname -m) == arm64 ]]; then
+if [[ $(uname -m) == arm64 ]] || [[ $(uname -m) == aarch64 ]]; then
   arch=arm64
 fi
 


### PR DESCRIPTION
Add aarch64 autodetection to the buildifier wrapper script. 