### PR TITLE
Converge files regex with keith/buildifier-prebuilt

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,11 +2,11 @@
   name: buildifier
   description: Format starlark code with buildifier
   entry: buildifier-wrapper.sh fix -mode=fix -lint=fix
-  files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE|WORKSPACE\.bazel|WORKSPACE\.bzlmod|MODULE\.bazel)$|\.BUILD$|\.bzl$'
+  files: '^(.*/)?(.*\.bzl|.*\.sky|.*\.bazel|BUILD|.*\.BUILD|BUILD\..*\.oss|WORKSPACE|WORKSPACE\.bzlmod|WORKSPACE\.oss|WORKSPACE\..*\.oss)$'
   language: script
 - id: buildifier-lint
   name: buildifier-lint
   description: Lint starlark code with buildifier
   entry: buildifier-wrapper.sh lint -mode=diff -lint=warn
-  files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE|WORKSPACE\.bazel|WORKSPACE\.bzlmod|MODULE\.bazel)$|\.BUILD$|\.bzl$'
+  files: '^(.*/)?(.*\.bzl|.*\.sky|.*\.bazel|BUILD|.*\.BUILD|BUILD\..*\.oss|WORKSPACE|WORKSPACE\.bzlmod|WORKSPACE\.oss|WORKSPACE\..*\.oss)$'
   language: script


### PR DESCRIPTION
I'm converging this regex with the files in here:

https://github.com/keith/buildifier-prebuilt/blob/7.3.1/runner.bash.template#L36-L45

I think this is a better and simpler regex. The previous one would fail to capture some .bazel files like the include MODULE.bazel files (foo.MODULE.bazel).