### PR TITLE
Support MODULE.bazel include files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,11 +2,11 @@
   name: buildifier
   description: Format starlark code with buildifier
   entry: buildifier-wrapper.sh fix -mode=fix -lint=fix
-  files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE|WORKSPACE\.bazel|WORKSPACE\.bzlmod|MODULE\.bazel)$|\.BUILD$|\.bzl$'
+  files: '^(.*/)?(.*\.bzl|.*\.sky|.*\.bazel|BUILD|.*\.BUILD|BUILD\..*\.oss|WORKSPACE|WORKSPACE\.bzlmod|WORKSPACE\.oss|WORKSPACE\..*\.oss)$'
   language: script
 - id: buildifier-lint
   name: buildifier-lint
   description: Lint starlark code with buildifier
   entry: buildifier-wrapper.sh lint -mode=diff -lint=warn
-  files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE|WORKSPACE\.bazel|WORKSPACE\.bzlmod|MODULE\.bazel)$|\.BUILD$|\.bzl$'
+  files: '^(.*/)?(.*\.bzl|.*\.sky|.*\.bazel|BUILD|.*\.BUILD|BUILD\..*\.oss|WORKSPACE|WORKSPACE\.bzlmod|WORKSPACE\.oss|WORKSPACE\..*\.oss)$'
   language: script


### PR DESCRIPTION
The current regex doesn't work for MODULE.bazel include files (usually named `<something>.MODULE.bazel`).

Also, I think it's easier if both `keith/buildifier-prebuilt` and `keith/pre-commit-buildifier` work on the same files :) So, I think this repo regex should match https://github.com/keith/buildifier-prebuilt/blob/7.3.1/runner.bash.template#L36-L45 since that one supports all the Bazel files I can think of.

P.S. a previous PR was auto-deleted when I renamed the branch, sorry for the noise!