### PR TITLE
Use wget instead of curl for buildifier download

### DIFF
--- a/buildifier-wrapper.sh
+++ b/buildifier-wrapper.sh
@@ -46,7 +46,15 @@ mkdir -p "$binary_dir"
 tmp_binary="$(mktemp --tmpdir="$binary_dir")"
 trap 'rm -f "$tmp_binary"' EXIT
 
-if ! wget --retry-connrefused --quiet --output-document "$tmp_binary" "$url"; then
+download() {
+  if which wget &> /dev/null; then
+    wget --retry-connrefused --quiet --output-document "$2" "$1"
+  else
+    curl --fail --location --retry 5 --retry-connrefused --silent --output "$2" "$1"
+  fi
+}
+
+if ! download "$url" "$tmp_binary"; then
   echo "error: failed to download buildifier" >&2
   exit 1
 fi

--- a/buildifier-wrapper.sh
+++ b/buildifier-wrapper.sh
@@ -46,7 +46,7 @@ mkdir -p "$binary_dir"
 tmp_binary="$(mktemp --tmpdir="$binary_dir")"
 trap 'rm -f "$tmp_binary"' EXIT
 
-if ! curl --fail --location --retry 5 --retry-connrefused --silent --output "$tmp_binary" "$url"; then
+if ! wget --retry-connrefused --quiet --output-document "$tmp_binary" "$url"; then
   echo "error: failed to download buildifier" >&2
   exit 1
 fi


### PR DESCRIPTION
Proposing the substition of `curl` with `wget` for downloading buildifier binary. The problem with `curl` is that there is a high variability in versions installed in different Linux distributions and so e.g. on Centos the script does not work out of the box due to a lack of support for the `--retry-connrefused` option and requires a cumbersome process for installing the right version. Using `wget` solves the problem.